### PR TITLE
Propagate DDR enablement from Java 9

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -267,8 +267,14 @@ endif
 # Adjust .spec files replacing references to gcc-4.6. Openjdk requires 4.8.2 or newer.
 SPEC_SED_SCRIPT := -e 's/gcc-4.6/gcc/g'
 
-# As DDR is not enabled we use sed to filter .spec files.
-SPEC_SED_SCRIPT += $(call SedDisable,module_ddr)
+# Adjust DDR enablement flags.
+ifeq (true,$(OPENJ9_ENABLE_DDR))
+  FEATURE_SED_SCRIPT += $(call SedEnable,opt_useOmrDdr)
+  SPEC_SED_SCRIPT    += $(call SedEnable,module_ddr)
+else
+  FEATURE_SED_SCRIPT += $(call SedDisable,opt_useOmrDdr)
+  SPEC_SED_SCRIPT    += $(call SedDisable,module_ddr)
+endif
 
 # Disable windows rebase.
 SPEC_SED_SCRIPT += $(call SedDisable,uma_windowsRebase)
@@ -397,6 +403,12 @@ build-j9 : run-preprocessors-j9
 	@$(CP) -p $(OUTPUTDIR)/vm/redirector/$(LIBRARY_PREFIX)jvm_b156$(SHARED_LIBRARY_SUFFIX) $(MODULES_LIBS_DIR)/java.base/j9vm/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX)
 	@$(MKDIR) -p $(MODULES_LIBS_DIR)/java.base/server
 	@$(CP) -p $(OUTPUTDIR)/vm/redirector/$(LIBRARY_PREFIX)jvm_b156$(SHARED_LIBRARY_SUFFIX) $(MODULES_LIBS_DIR)/java.base/server/$(LIBRARY_PREFIX)jvm$(SHARED_LIBRARY_SUFFIX)
+
+ifeq (true,$(OPENJ9_ENABLE_DDR))
+	@$(ECHO) Copying j9ddr.dat
+	@$(MKDIR) -p $(MODULES_LIBS_DIR)/java.base/$(OPENJ9_LIBS_SUBDIR)
+	@$(CP) -p $(OUTPUTDIR)/vm/j9ddr.dat $(MODULES_LIBS_DIR)/java.base/$(OPENJ9_LIBS_SUBDIR)/
+endif
 
 J9JCL_SOURCES_DONEFILE := $(MAKESUPPORT_OUTPUTDIR)/j9jcl_sources.done
 

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -1,7 +1,6 @@
 # ===========================================================================
 # (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
-#
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
 # published by the Free Software Foundation.
@@ -14,7 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License version
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
-#
 # ===========================================================================
 
 AC_DEFUN_ONCE([CUSTOM_EARLY_HOOK],
@@ -41,6 +39,7 @@ AC_DEFUN_ONCE([CUSTOM_EARLY_HOOK],
   OPENJ9_PLATFORM_SETUP
   OPENJDK_VERSION_DETAILS
   OPENJ9_CONFIGURE_CUDA
+  OPENJ9_CONFIGURE_DDR
   OPENJ9_CONFIGURE_NUMA
   OPENJ9_THIRD_PARTY_REQUIREMENTS
 ])
@@ -106,6 +105,34 @@ AC_DEFUN([OPENJ9_CONFIGURE_CUDA],
   AC_SUBST(OPENJ9_ENABLE_CUDA)
   AC_SUBST(OPENJ9_CUDA_HOME)
   AC_SUBST(OPENJ9_GDK_HOME)
+])
+
+AC_DEFUN([OPENJ9_CONFIGURE_DDR],
+[
+  AC_MSG_CHECKING([for ddr])
+  AC_ARG_ENABLE([ddr], [AS_HELP_STRING([--enable-ddr], [enable DDR support @<:@disabled@:>@])])
+  if test "x$enable_ddr" = xyes ; then
+    AC_MSG_RESULT([yes (explicitly enabled)])
+    OPENJ9_ENABLE_DDR=true
+  elif test "x$enable_ddr" = xno ; then
+    AC_MSG_RESULT([no (explicitly disabled)])
+    OPENJ9_ENABLE_DDR=false
+  elif test "x$enable_ddr" = x ; then
+    case "$OPENJ9_PLATFORM_CODE" in
+      xa64|xl64|xz64)
+        AC_MSG_RESULT([yes (default for $OPENJ9_PLATFORM_CODE)])
+        OPENJ9_ENABLE_DDR=true
+        ;;
+      *)
+        AC_MSG_RESULT([no (default for $OPENJ9_PLATFORM_CODE)])
+        OPENJ9_ENABLE_DDR=false
+        ;;
+    esac
+  else
+    AC_MSG_ERROR([--enable-ddr accepts no argument])
+  fi
+
+  AC_SUBST(OPENJ9_ENABLE_DDR)
 ])
 
 AC_DEFUN([OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU],

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -42,6 +42,9 @@ ifneq (,@OPENJ9_GDK_HOME@)
 export GDK_HOME         := @OPENJ9_GDK_HOME@
 endif
 
+# DDR
+OPENJ9_ENABLE_DDR       := @OPENJ9_ENABLE_DDR@
+
 # for constructing version output
 COMPILER_VERSION_STRING := @COMPILER_VERSION_STRING@
 USERNAME                := @USERNAME@

--- a/closed/autoconf/generated-configure.sh
+++ b/closed/autoconf/generated-configure.sh
@@ -962,6 +962,7 @@ SDKROOT
 XCODEBUILD
 DEVKIT_LIB_DIR
 FREEMARKER_JAR
+OPENJ9_ENABLE_DDR
 OPENJ9_GDK_HOME
 OPENJ9_CUDA_HOME
 OPENJ9_ENABLE_CUDA
@@ -1141,6 +1142,7 @@ with_cpu_port
 with_cuda
 with_gdk
 enable_cuda
+enable_ddr
 with_freemarker_jar
 with_devkit
 with_sys_root
@@ -1990,6 +1992,7 @@ Optional Features:
   --enable-debug          set the debug level to fastdebug (shorthand for
                           --with-debug-level=fastdebug) [disabled]
   --enable-cuda           enable CUDA support [disabled]
+  --enable-ddr            enable DDR support [disabled]
   --enable-headless-only  only build headless (no GUI) support [disabled]
   --enable-full-docs      build complete documentation [enabled if all tools
                           found]
@@ -5211,7 +5214,6 @@ VS_SDK_PLATFORM_NAME_2013=
 # ===========================================================================
 # (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
-#
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
 # published by the Free Software Foundation.
@@ -5224,7 +5226,6 @@ VS_SDK_PLATFORM_NAME_2013=
 #
 # You should have received a copy of the GNU General Public License version
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
-#
 # ===========================================================================
 
 
@@ -5246,8 +5247,10 @@ VS_SDK_PLATFORM_NAME_2013=
 
 
 
+
+
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1522310070
+DATE_WHEN_GENERATED=1522342326
 
 ###############################################################################
 #
@@ -17586,6 +17589,41 @@ $as_echo "no (default)" >&6; }
   fi
 
 
+
+
+
+
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for ddr" >&5
+$as_echo_n "checking for ddr... " >&6; }
+  # Check whether --enable-ddr was given.
+if test "${enable_ddr+set}" = set; then :
+  enableval=$enable_ddr;
+fi
+
+  if test "x$enable_ddr" = xyes ; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes (explicitly enabled)" >&5
+$as_echo "yes (explicitly enabled)" >&6; }
+    OPENJ9_ENABLE_DDR=true
+  elif test "x$enable_ddr" = xno ; then
+    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no (explicitly disabled)" >&5
+$as_echo "no (explicitly disabled)" >&6; }
+    OPENJ9_ENABLE_DDR=false
+  elif test "x$enable_ddr" = x ; then
+    case "$OPENJ9_PLATFORM_CODE" in
+      xa64|xl64|xz64)
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes (default for $OPENJ9_PLATFORM_CODE)" >&5
+$as_echo "yes (default for $OPENJ9_PLATFORM_CODE)" >&6; }
+        OPENJ9_ENABLE_DDR=true
+        ;;
+      *)
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no (default for $OPENJ9_PLATFORM_CODE)" >&5
+$as_echo "no (default for $OPENJ9_PLATFORM_CODE)" >&6; }
+        OPENJ9_ENABLE_DDR=false
+        ;;
+    esac
+  else
+    as_fn_error $? "--enable-ddr accepts no argument" "$LINENO" 5
+  fi
 
 
 

--- a/closed/make/DDR-gensrc.gmk
+++ b/closed/make/DDR-gensrc.gmk
@@ -1,0 +1,90 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+# The main target.
+all :
+
+ifeq (,$(wildcard $(SPEC)))
+  $(error BuildDDR.gmk needs SPEC set to a proper spec.gmk)
+endif
+
+include $(SPEC)
+include $(TOPDIR)/make/common/MakeBase.gmk
+include $(TOPDIR)/make/common/JavaCompilation.gmk
+include $(TOPDIR)/make/common/SetupJavaCompilers.gmk
+
+# Supporting definitions.
+DDR_SUPPORT_DIR := $(SUPPORT_OUTPUTDIR)/ddr
+DDR_VM_SRC_ROOT := $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src
+
+#############################################################################
+
+# Build a jar containing the code generators.
+$(eval $(call SetupJavaCompilation,BUILD_DDR_TOOLS, \
+	SETUP := GENERATE_OLDBYTECODE, \
+	BIN := $(DDR_SUPPORT_DIR)/tools, \
+	CLASSPATH := $(addprefix $(JDK_OUTPUTDIR)/modules/, java.base openj9.dtfj), \
+	SRC := $(DDR_VM_SRC_ROOT), \
+	INCLUDE_FILES := $(addsuffix .java,$(subst .,/, \
+		com.ibm.j9ddr.BytecodeGenerator \
+		com.ibm.j9ddr.CTypeParser \
+		com.ibm.j9ddr.StructureHeader \
+		com.ibm.j9ddr.StructureReader \
+		com.ibm.j9ddr.StructureTypeManager \
+		com.ibm.j9ddr.logging.LoggerNames \
+		com.ibm.j9ddr.tools.FlagStructureList \
+		com.ibm.j9ddr.tools.PointerGenerator \
+		com.ibm.j9ddr.tools.StructureStubGenerator \
+		com.ibm.j9ddr.tools.store.J9DDRStructureStore \
+		com.ibm.j9ddr.tools.store.StructureKey \
+		com.ibm.j9ddr.tools.store.StructureMismatchError \
+		)), \
+	))
+
+#############################################################################
+
+# The superset file is built with the VM.
+DDR_SUPERSET_FILE := $(OUTPUTDIR)/vm/superset.dat
+
+# Generate Java pointer classes.
+DDR_POINTERS_MARKER := $(DDR_SUPPORT_DIR)/pointers.done
+
+$(DDR_POINTERS_MARKER) : $(DDR_SUPERSET_FILE) $(BUILD_DDR_TOOLS)
+	@$(ECHO) Generating DDR pointer classes
+	@$(RM) -rf $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/vm29/pointer/generated/
+	@$(JAVA) -cp $(BUILD_DDR_TOOLS_BIN) com.ibm.j9ddr.tools.PointerGenerator \
+		-f $(dir $(DDR_SUPERSET_FILE)) \
+		-s $(notdir $(DDR_SUPERSET_FILE)) \
+		-p com.ibm.j9ddr.vm29.pointer.generated \
+		-v 29 \
+		-o $(DDR_VM_SRC_ROOT)
+	@$(TOUCH) $@
+
+# Generate Java structure stub classes.
+DDR_STRUCTURES_MARKER := $(DDR_SUPPORT_DIR)/structures.done
+
+$(DDR_STRUCTURES_MARKER) : $(DDR_SUPERSET_FILE) $(BUILD_DDR_TOOLS)
+	@$(ECHO) Generating DDR structure stubs
+	@$(RM) -rf $(DDR_VM_SRC_ROOT)/com/ibm/j9ddr/vm29/structure/
+	@$(JAVA) -cp $(BUILD_DDR_TOOLS_BIN) com.ibm.j9ddr.tools.StructureStubGenerator \
+		-f $(dir $(DDR_SUPERSET_FILE)) \
+		-s $(notdir $(DDR_SUPERSET_FILE)) \
+		-p com.ibm.j9ddr.vm29.structure \
+		-o $(DDR_VM_SRC_ROOT)
+	@$(TOUCH) $@
+
+all : $(DDR_POINTERS_MARKER) $(DDR_STRUCTURES_MARKER)

--- a/closed/make/DDR-jar.gmk
+++ b/closed/make/DDR-jar.gmk
@@ -1,0 +1,64 @@
+# ===========================================================================
+# (c) Copyright IBM Corp. 2018, 2018 All Rights Reserved
+# ===========================================================================
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
+# ===========================================================================
+
+# The main target.
+all :
+
+ifeq (,$(wildcard $(SPEC)))
+  $(error BuildDDR.gmk needs SPEC set to a proper spec.gmk)
+endif
+
+include $(SPEC)
+include $(TOPDIR)/make/common/MakeBase.gmk
+include $(TOPDIR)/make/common/JavaCompilation.gmk
+include $(TOPDIR)/make/common/SetupJavaCompilers.gmk
+
+# Supporting definitions.
+DDR_CLASSES_BIN := $(SUPPORT_OUTPUTDIR)/ddr/classes
+
+# We depend upon class files from these modules.
+DDR_CLASSPATH := $(addprefix $(JDK_OUTPUTDIR)/modules/, \
+		java.base \
+		java.desktop \
+		openj9.dtfj \
+		openj9.traceformat \
+	)
+
+DDR_SRC_EXCLUDES := com/ibm/j9ddr/tools/ant
+
+ifeq (,$(filter mz31 mz64,$(OPENJ9_PLATFORM_CODE)))
+DDR_SRC_EXCLUDES += com/ibm/j9ddr/corereaders/tdump
+endif
+
+$(eval $(call SetupJavaCompilation,BUILD_DDR_CLASSES, \
+	SETUP := GENERATE_USINGJDKBYTECODE, \
+	BIN := $(DDR_CLASSES_BIN), \
+	CLASSPATH := $(DDR_CLASSPATH), \
+	SRC := $(OPENJ9_TOPDIR)/debugtools/DDR_VM/src, \
+	EXCLUDES := $(DDR_SRC_EXCLUDES), \
+	COPY := com/ibm/j9ddr/StructureAliases29.dat, \
+	))
+
+$(eval $(call SetupJarArchive,BUILD_DDR_JAR, \
+	DEPENDENCIES := $(BUILD_DDR_CLASSES), \
+	SRCS := $(DDR_CLASSES_BIN), \
+	SUFFIXES := .class .dat .properties, \
+	EXCLUDES := com/ibm/j9ddr/vm29/structure, \
+	JAR := $(call FindLibDirForModule, openj9.dtfj)/ddr/j9ddr.jar, \
+	))
+
+all : $(BUILD_DDR_JAR)

--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -1,10 +1,9 @@
 # ===========================================================================
 # (c) Copyright IBM Corp. 2017, 2018 All Rights Reserved
 # ===========================================================================
-# 
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
-# published by the Free Software Foundation.  
+# published by the Free Software Foundation.
 #
 # This code is distributed in the hope that it will be useful, but WITHOUT
 # ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
@@ -14,7 +13,6 @@
 #
 # You should have received a copy of the GNU General Public License version
 # 2 along with this work; if not, see <http://www.gnu.org/licenses/>.
-# 
 # ===========================================================================
 
 CLEAN_DIRS += vm
@@ -28,14 +26,14 @@ CLEAN_DIRS += vm
 	#
 
 JVM_VARIANT_TARGETS := j9vm-build
-JVM_MAIN_TARGETS := j9vm-build j9vm-compose-buildjvm 
+JVM_MAIN_TARGETS := j9vm-build j9vm-compose-buildjvm
 JVM_BUILD_TARGETS := j9vm-build
-JVM_TOOLS_TARGETS := 
-JVM_TEST_IMAGE_TARGETS := 
+JVM_TOOLS_TARGETS :=
+JVM_TEST_IMAGE_TARGETS :=
 DEFAULT_JMOD_DEPS := j9vm-compose-buildjvm
 
 PHASE_MAKEDIRS += $(TOPDIR)/closed/closed_make
-	
+
 java.base-libs : j9vm-build
 
 j9vm-build : buildtools-langtools
@@ -51,5 +49,19 @@ openj9-jdk-image : jdk-image j9vm-build
 
 openj9-jre-image : jre-image j9vm-build
 	+($(CD) $(TOPDIR)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) stage_openj9_jre_image)
+
+ifeq (true,$(OPENJ9_ENABLE_DDR))
+
+.PHONY : openj9.dtfj-ddr-gensrc openj9.dtfj-ddr-jar
+
+openj9.dtfj-ddr-gensrc : j9vm-build $(addsuffix -java, java.base java.desktop openj9.dtfj openj9.traceformat)
+	+$(MAKE) -f $(TOPDIR)/closed/make/DDR-gensrc.gmk SPEC=$(SPEC)
+
+openj9.dtfj-ddr-jar : openj9.dtfj-ddr-gensrc
+	+$(MAKE) -f $(TOPDIR)/closed/make/DDR-jar.gmk SPEC=$(SPEC)
+
+openj9.dtfj-jmod : openj9.dtfj-ddr-jar
+
+endif # OPENJ9_ENABLE_DDR
 
 ALL_TARGETS += openj9-jdk-image openj9-jre-image

--- a/make/autoconf/generated-configure.sh
+++ b/make/autoconf/generated-configure.sh
@@ -5187,7 +5187,7 @@ VS_SDK_PLATFORM_NAME_2013=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1522310070
+DATE_WHEN_GENERATED=1522342326
 
 ###############################################################################
 #


### PR DESCRIPTION
Enabled by default for p, x and z Linux (as it is for Java 8 and Java 9).