### PR TITLE
Missing ARM support in main.gmk

### DIFF
--- a/closed/make/Main.gmk
+++ b/closed/make/Main.gmk
@@ -40,7 +40,11 @@ j9vm-build : buildtools-langtools
 	+($(CD) $(TOPDIR)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) VERSION_MAJOR=$(VERSION_FEATURE) build-j9)
 
 j9vm-compose-buildjvm : j9vm-build $(J9JCL_GENSRC_MAKEFILE)
+ifeq ($(OPENJDK_BUILD_CPU),$(OPENJDK_TARGET_CPU))
 	+($(CD) $(TOPDIR)/closed && $(MAKE) -f OpenJ9.gmk SPEC=$(SPEC) stage_openj9_build_jdk)
+else
+	@$(ECHO) Cross compile detected, skipping stage_openj9_build_jdk
+endif
 
 product-images : openj9-jdk-image openj9-jre-image
 


### PR DESCRIPTION
Restored the missing ARM support to disable attempting to stage the build jdk
(since for an arm cross compile we provide a pre-built build jdk) in main.gmk.

Signed-off-by: James Kingdon <jkingdon@ca.ibm.com>