### PR TITLE
Create noncompressedrefs build (step 1)

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -191,19 +191,32 @@ AC_DEFUN([OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU],
 
 AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
 [
+  AC_ARG_WITH(noncompressedrefs, [AS_HELP_STRING([--with-noncompressedrefs],
+      [build non-compressedrefs vm (large heap)])])
+      
   # When compiling natively host_cpu and build_cpu are the same. But when
   # cross compiling we need to work with the host_cpu (which is where the final
   # JVM will run).
   OPENJ9_PLATFORM_EXTRACT_VARS_FROM_CPU($host_cpu)
-  OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}_cmprssptrs"
-  OPENJ9_LIBS_SUBDIR=compressedrefs
+  
+  if test "x$with_noncompressedrefs" = x; then
+    OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}_cmprssptrs"
+    OPENJ9_LIBS_SUBDIR=compressedrefs
+  else 
+    OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}"
+    OPENJ9_LIBS_SUBDIR=default
+  fi
 
   if test "x$OPENJ9_CPU" = xx86-64; then
     if test "x$OPENJDK_BUILD_OS" = xlinux; then
       OPENJ9_PLATFORM_CODE=xa64
     elif test "x$OPENJDK_BUILD_OS" = xwindows; then
       OPENJ9_PLATFORM_CODE=wa64
-      OPENJ9_BUILDSPEC="win_x86-64_cmprssptrs"
+      if test "x$OPENJ9_LIBS_SUBDIR" = xdefault; then
+        OPENJ9_BUILDSPEC="win_x86-64"
+      else
+        OPENJ9_BUILDSPEC="win_x86-64_cmprssptrs"
+      fi
     elif test "x$OPENJDK_BUILD_OS" = xmacosx; then
       OPENJ9_PLATFORM_CODE=oa64
       OPENJ9_BUILDSPEC="osx_x86-64"
@@ -212,7 +225,11 @@ AC_DEFUN_ONCE([OPENJ9_PLATFORM_SETUP],
     fi
   elif test "x$OPENJ9_CPU" = xppc-64_le; then
     OPENJ9_PLATFORM_CODE=xl64
-    OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_ppc-64_cmprssptrs_le_gcc"
+    if test "x$OPENJ9_LIBS_SUBDIR" = xdefault; then
+      OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_ppc-64_le_gcc"
+    else
+      OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_ppc-64_cmprssptrs_le_gcc"
+    fi
   elif test "x$OPENJ9_CPU" = x390-64; then
     OPENJ9_PLATFORM_CODE=xz64
   elif test "x$OPENJ9_CPU" = xppc-64; then

--- a/closed/autoconf/generated-configure.sh
+++ b/closed/autoconf/generated-configure.sh
@@ -1141,6 +1141,7 @@ enable_debug
 with_debug_level
 with_jvm_variants
 with_cpu_port
+with_noncompressedrefs
 with_cmake
 with_cuda
 with_gdk
@@ -2069,6 +2070,8 @@ Optional Packages:
                           (server,client,minimal,core,zero,custom) [server]
   --with-cpu-port         specify sources to use for Hotspot 64-bit ARM port
                           (arm64,aarch64) [aarch64]
+  --with-noncompressedrefs
+                          build non-compressedrefs vm (large heap)
   --with-cmake            enable building openJ9 with CMake
   --with-cuda             use this directory as CUDA_HOME
   --with-gdk              use this directory as GDK_HOME
@@ -5256,7 +5259,7 @@ VS_SDK_PLATFORM_NAME_2013=
 
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1523293808
+DATE_WHEN_GENERATED=1525092852
 
 ###############################################################################
 #
@@ -17155,6 +17158,13 @@ $as_echo "$as_me: Unknown variant(s) specified: $INVALID_VARIANTS" >&6;}
 
 # With basic setup done, call the custom early hook.
 
+
+# Check whether --with-noncompressedrefs was given.
+if test "${with_noncompressedrefs+set}" = set; then :
+  withval=$with_noncompressedrefs;
+fi
+
+
   # When compiling natively host_cpu and build_cpu are the same. But when
   # cross compiling we need to work with the host_cpu (which is where the final
   # JVM will run).
@@ -17181,15 +17191,25 @@ $as_echo "$as_me: Unknown variant(s) specified: $INVALID_VARIANTS" >&6;}
       ;;
   esac
 
-  OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}_cmprssptrs"
-  OPENJ9_LIBS_SUBDIR=compressedrefs
+
+  if test "x$with_noncompressedrefs" = x; then
+    OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}_cmprssptrs"
+    OPENJ9_LIBS_SUBDIR=compressedrefs
+  else
+    OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_${OPENJ9_CPU}"
+    OPENJ9_LIBS_SUBDIR=default
+  fi
 
   if test "x$OPENJ9_CPU" = xx86-64; then
     if test "x$OPENJDK_BUILD_OS" = xlinux; then
       OPENJ9_PLATFORM_CODE=xa64
     elif test "x$OPENJDK_BUILD_OS" = xwindows; then
       OPENJ9_PLATFORM_CODE=wa64
-      OPENJ9_BUILDSPEC="win_x86-64_cmprssptrs"
+      if test "x$OPENJ9_LIBS_SUBDIR" = xdefault; then
+        OPENJ9_BUILDSPEC="win_x86-64"
+      else
+        OPENJ9_BUILDSPEC="win_x86-64_cmprssptrs"
+      fi
     elif test "x$OPENJDK_BUILD_OS" = xmacosx; then
       OPENJ9_PLATFORM_CODE=oa64
       OPENJ9_BUILDSPEC="osx_x86-64"
@@ -17198,7 +17218,11 @@ $as_echo "$as_me: Unknown variant(s) specified: $INVALID_VARIANTS" >&6;}
     fi
   elif test "x$OPENJ9_CPU" = xppc-64_le; then
     OPENJ9_PLATFORM_CODE=xl64
-    OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_ppc-64_cmprssptrs_le_gcc"
+    if test "x$OPENJ9_LIBS_SUBDIR" = xdefault; then
+      OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_ppc-64_le_gcc"
+    else
+      OPENJ9_BUILDSPEC="${OPENJDK_BUILD_OS}_ppc-64_cmprssptrs_le_gcc"
+    fi
   elif test "x$OPENJ9_CPU" = x390-64; then
     OPENJ9_PLATFORM_CODE=xz64
   elif test "x$OPENJ9_CPU" = xppc-64; then
@@ -17220,7 +17244,7 @@ $as_echo "$as_me: Unknown variant(s) specified: $INVALID_VARIANTS" >&6;}
   OPENJDK_SHA=`git -C $TOPDIR rev-parse --short HEAD`
   LAST_TAGGED_SHA=`git -C $TOPDIR rev-list --tags="jdk-10*" --max-count=1 2>/dev/null`
   if test "x$LAST_TAGGED_SHA" != x; then
-    OPENJDK_TAG=`git -C $TOPDIR describe --abbrev=0 --tags "$LAST_TAGGED_SHA"`
+    OPENJDK_TAG=`git -C $TOPDIR describe --tags "$LAST_TAGGED_SHA"`
   else
     OPENJDK_TAG=
   fi

--- a/make/autoconf/generated-configure.sh
+++ b/make/autoconf/generated-configure.sh
@@ -5187,7 +5187,7 @@ VS_SDK_PLATFORM_NAME_2013=
 #CUSTOM_AUTOCONF_INCLUDE
 
 # Do not change or remove the following line, it is needed for consistency checks:
-DATE_WHEN_GENERATED=1523293808
+DATE_WHEN_GENERATED=1525092852
 
 ###############################################################################
 #


### PR DESCRIPTION
- Add config option --with-noncompressedrefs to toggle build
- Remove hardcoded references to compressedrefs from makefiles

Addition to issue eclipse/openj9#1669

Signed-off-by: Theresa Mammarella <Theresa.T.Mammarella@ibm.com>