### PR TITLE
Add ignores needed when configured using '--with-freetype-src'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@
 /openj9
 # exclude optional eclipse project file
 /.project
+
+# ignore derived artifacts created when configure option '--with-freetype-src' is used
+/freetype.bat
+/freetype.log


### PR DESCRIPTION
Build steps in lib-freetype.m4 create freetype.bat and freetype.log: ignore those files.