### PR TITLE
Cmake simplifications

### DIFF
--- a/closed/OpenJ9.gmk
+++ b/closed/OpenJ9.gmk
@@ -369,7 +369,7 @@ run-preprocessors-j9 : stage-j9 \
 		&& cd $(OUTPUTDIR)/vm \
 		&& $(MAKE) $(MAKEFLAGS) -f buildtools.mk \
 			BUILD_ID=$(BUILD_ID) \
-			CMAKE=$(CMAKE) $(if $(findstring true,$(OPENJ9_ENABLE_CMAKE)),ENABLE_CMAKE=true CALLED_BY_SOURCE_ZIP=yes) \
+			CMAKE=$(CMAKE) \
 			EXTRA_CONFIGURE_ARGS=$(OMR_EXTRA_CONFIGURE_ARGS) \
 			FREEMARKER_JAR="$(FREEMARKER_JAR)" \
 			J9VM_SHA=$(OPENJ9_SHA) \


### PR DESCRIPTION
Don't set CALLED_BY_SOURCE_ZIP=yes when using cmake. Previously it supressed actions for make targets that are no longer used with cmake. Now, CALLED_BY_SOURCE_ZIP only affects how OMR is
configured.

Use OPENJ9_ENABLE_CMAKE directly, instead of ENABLE_CMAKE.

buildtools.mk includes spec.gmk and thus has direct access to OPENJ9_ENABLE_CMAKE.

Depends upon https://github.com/eclipse/openj9/pull/1907.