### PR TITLE
Fix omr configure issues with ccache

### DIFF
--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -68,8 +68,11 @@ OPENJ9_PLATFORM_CODE    := @OPENJ9_PLATFORM_CODE@
 
 OPENJ9_LIBS_SUBDIR      := @OPENJ9_LIBS_SUBDIR@
 
-# Shell to configure OMR
-export CONFIG_SHELL     := @CONFIG_SHELL@
+# Export autoconf cache variables for CC/CXX
+# This is for the case where ccache is enabled
+# It ensures that OMR autoconf uses the compiler, not ccache
+export ac_cv_prog_CC    := @CC@
+export ac_cv_prog_CXX   := @CXX@
 
 ifeq ($(OPENJDK_TARGET_OS), windows)
   # Set environment variables for Microsoft Visual Studio toolchain.


### PR DESCRIPTION
Export the autoconf cache variables for CC/CXX. This determines the program
autoconf runs its tests on, without clobbering the CC/CXX variables.

Also remove the CONFIG_SHELL variable export as it is not required, and
does not solve the underlying issue

Signed-off-by: Devin Nakamura <devinn@ca.ibm.com>