### PR TITLE
Prevent the ClassLoader object being GCd in the middle of a method

### DIFF
--- a/src/java.base/share/classes/java/util/ResourceBundle.java
+++ b/src/java.base/share/classes/java/util/ResourceBundle.java
@@ -25,7 +25,7 @@
 
 /*
  * (C) Copyright Taligent, Inc. 1996, 1997 - All Rights Reserved
- * (C) Copyright IBM Corp. 1996 - 1999 - All Rights Reserved
+ * (C) Copyright IBM Corp. 1996 - 2018 - All Rights Reserved
  *
  * The original version of this source code and documentation
  * is copyrighted and owned by Taligent, Inc., a wholly-owned
@@ -1696,7 +1696,12 @@ public abstract class ResourceBundle {
         Reference.reachabilityFence(callerModule);
         Reference.reachabilityFence(module);
 
-        return bundle;
+        //The OpenJ9 GC might collect the loader before we return here. This prevents that.
+        try {
+            return bundle;
+        } finally {
+            Reference.reachabilityFence(loader);
+        }
     }
 
     /**


### PR DESCRIPTION
In ResourceBundle, the private method "getBundleFromModule" takes
a ClassLoader parameter, but doesn't appear to use it directly.
If a GC cycle occurs during the method execution, we can lose that
ClassLoader, causing a bug whose most visible symptom is us being
unable to find a locale-specific entity that definitely exists.

E.g. If we have Stuff_fr.class and Stuff_fr_CA.class, and we ask for
"Stuff" with the locale "fr, CA", then a garbage collection here
may cause us to return Stuff_fr.class (as if Stuff_fr_CA.class did not
exist).

Using the loader parameter for an operation at the very end of the
method prevents GC from collecting it, and prevents this problem.

Signed-off-by: Adam Farley <adam.farley@uk.ibm.com>