### PR TITLE
Add doPrivileged for security sensitive calls

### DIFF
--- a/src/java.base/share/classes/jdk/internal/loader/BuiltinClassLoader.java
+++ b/src/java.base/share/classes/jdk/internal/loader/BuiltinClassLoader.java
@@ -1,6 +1,6 @@
 /*
  * ===========================================================================
- * (c) Copyright IBM Corp. 2015, 2017 All Rights Reserved
+ * (c) Copyright IBM Corp. 2015, 2018 All Rights Reserved
  * ===========================================================================
  */
 
@@ -849,9 +849,10 @@ public class BuiltinClassLoader
      */
     private Class<?> findClassInModuleOrNull(LoadedModule loadedModule, String cn) {
 		Class<?> c = null;												//IBM-shared_classes_misc
-		ModuleReader reader = moduleReaderFor(loadedModule.mref());		//IBM-shared_classes_misc
+		PrivilegedAction<ModuleReader> paModuleReaderFor = () -> moduleReaderFor(loadedModule.mref()); //IBM-shared_classes_misc
+		ModuleReader reader = AccessController.doPrivileged(paModuleReaderFor); //IBM-shared_classes_misc
 		if (!(reader instanceof PatchedModuleReader)) {					//IBM-shared_classes_misc
-			c = findClassInSharedClassesCache(cn, loadedModule, false);	//IBM-shared_classes_misc												
+			c = findClassInSharedClassesCache(cn, loadedModule, false);	//IBM-shared_classes_misc
 		}																//IBM-shared_classes_misc
 		if (null != c) {												//IBM-shared_classes_misc
 			return c;													//IBM-shared_classes_misc


### PR DESCRIPTION
Add `doPrivileged` for security sensitive calls

Otherwise following security exception might be thrown in certain testcase.
```
Caused by: java.security.AccessControlException: Access denied ("java.lang.RuntimePermission" "accessSystemModules")
	at java.base/java.security.AccessController.throwACE(AccessController.java:176)
	at java.base/java.security.AccessController.checkPermissionHelper(AccessController.java:237)
	at java.base/java.security.AccessController.checkPermission(AccessController.java:373)
	at java.base/java.lang.SecurityManager.checkPermission(SecurityManager.java:322)
	at java.base/jdk.internal.module.SystemModuleFinders$SystemModuleReader.checkPermissionToConnect(SystemModuleFinders.java:406)
	at java.base/jdk.internal.module.SystemModuleFinders$SystemModuleReader.<init>(SystemModuleFinders.java:414)
	at java.base/jdk.internal.module.SystemModuleFinders$2.get(SystemModuleFinders.java:315)
	at java.base/jdk.internal.module.SystemModuleFinders$2.get(SystemModuleFinders.java:312)
	at java.base/jdk.internal.module.ModuleReferenceImpl.open(ModuleReferenceImpl.java:93)
	at java.base/jdk.internal.loader.BuiltinClassLoader$5.apply(BuiltinClassLoader.java:1291)
	at java.base/jdk.internal.loader.BuiltinClassLoader$5.apply(BuiltinClassLoader.java:1288)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705)
	at java.base/jdk.internal.loader.BuiltinClassLoader.moduleReaderFor(BuiltinClassLoader.java:1299)
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassInModuleOrNull(BuiltinClassLoader.java:852)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:777)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:812)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:781)
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:751)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:1032)
```

Ported from https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/24.

Reviewer: @pshipton
FYI: @hangshao0 @DanHeidinga

Signed-off-by: Jason Feng <fengj@ca.ibm.com>